### PR TITLE
Output public EIPs for Nat Gateways

### DIFF
--- a/modules/nat-gateways/README.md
+++ b/modules/nat-gateways/README.md
@@ -68,4 +68,5 @@ module "private_subnets" {
 | Name | Description |
 |------|-------------|
 | nat_gateway_count | The number of gateways |
+| nat_gateway_public_ips | The public EIPs of the Nat Gateways
 | nat_gateway_ids | List of gateway IDs |

--- a/modules/nat-gateways/output.tf
+++ b/modules/nat-gateways/output.tf
@@ -7,3 +7,8 @@ output "nat_gateway_ids" {
   description = "List of gateway IDs"
   value       = aws_nat_gateway.natgw.*.id
 }
+
+output "nat_gateway_public_ips" {
+  description = "List of public IPs belonging to the Nat Gateways"
+  value       = aws_eip.natgw.*.public_ip
+}


### PR DESCRIPTION
We have a use-case that requires us to allow connections from our infrastructure into a whitelisted ALB.  In order to do this, we need to know the IPs of the Nat Gateways.

This PR adds them to the outputs of the `nat_gateway` submodule.