### PR TITLE
Allow tags for specific resource types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ module "vpc" {
 
   private_cidr_block   = "10.112.16.0/20"
   private_subnet_count = 3
+
+  # Tags for all resources that support them.
+  tags = {
+    Name = "my-vpc"
+  }
+
+  # Override tags for specific resource types.
+  tags_for_resource = {
+    aws_vpc = {
+      "Name"                             = "my-vpc"
+      "kubernetes.io/cluster/my-cluster" = "shared"
+    }
+    aws_subnet = {
+      "Name"                             = "my-vpc"
+      "kubernetes.io/cluster/my-cluster" = "shared"
+    }
+  }
 }
 ```
 
@@ -44,18 +61,19 @@ module "vpc" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | availability_zones | A list of availability zones to create subnets in | list | - | yes |
-| domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | `` | no |
-| domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `<list>` | no |
+| domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | - | no |
+| domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `AmazonProvidedDNS` | no |
 | enable_dns_hostnames | Enable DNS hostnames in the VPC | string | `false` | no |
 | enable_dns_support | Enable DNS support in the VPC | string | `true` | no |
 | map_public_ip_on_launch | Assign a public IP address to instances launched into the public subnets | string | `false` | no |
 | private_cidr_block | The larger CIDR block to use for calculating individual private subnet CIDR blocks | string | - | yes |
-| private_propagating_vgws | A list of virtual gateways for route propagation in the private subnets | list | `<list>` | no |
+| private_propagating_vgws | A list of virtual gateways for route propagation in the private subnets | list | - | no |
 | private_subnet_count | The number of private subnets to create | string | - | yes |
 | public_cidr_block | The larger CIDR block to use for calculating individual public subnet CIDR blocks | string | - | yes |
-| public_propagating_vgws | A list of virtual gateways for route propagation in the public subnets | list | `<list>` | no |
+| public_propagating_vgws | A list of virtual gateways for route propagation in the public subnets | list | - | no |
 | public_subnet_count | The number of public subnets to create | string | - | yes |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
 | vpc_cidr_block | The CIDR block for the VPC | string | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,8 @@ module "vpc" {
   enable_dns_support   = var.enable_dns_support
   enable_dns_hostnames = var.enable_dns_hostnames
 
-  tags = var.tags
+  tags              = var.tags
+  tags_for_resource = var.tags_for_resource
 }
 
 module "public_subnets" {
@@ -20,7 +21,8 @@ module "public_subnets" {
   subnet_count       = var.public_subnet_count
   availability_zones = var.availability_zones
 
-  tags = var.tags
+  tags              = var.tags
+  tags_for_resource = var.tags_for_resource
 }
 
 module "nat_gateways" {
@@ -29,7 +31,8 @@ module "nat_gateways" {
   subnet_count = module.public_subnets.subnet_count
   subnet_ids   = module.public_subnets.subnet_ids
 
-  tags = var.tags
+  tags              = var.tags
+  tags_for_resource = var.tags_for_resource
 }
 
 module "private_subnets" {
@@ -44,5 +47,6 @@ module "private_subnets" {
   subnet_count       = var.private_subnet_count
   availability_zones = var.availability_zones
 
-  tags = var.tags
+  tags              = var.tags
+  tags_for_resource = var.tags_for_resource
 }

--- a/modules/nat-gateways/README.md
+++ b/modules/nat-gateways/README.md
@@ -61,7 +61,8 @@ module "private_subnets" {
 |------|-------------|:----:|:-----:|:-----:|
 | subnet_count | The number of subnets to create gateways in, must match length of subnet_ids | string | - | yes |
 | subnet_ids | A list of subnets to create gateways in | list | - | yes |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
 
 ## Outputs
 

--- a/modules/nat-gateways/main.tf
+++ b/modules/nat-gateways/main.tf
@@ -9,5 +9,5 @@ resource "aws_nat_gateway" "natgw" {
 
   allocation_id = element(aws_eip.natgw.*.id, count.index)
   subnet_id     = element(var.subnet_ids, count.index)
-  tags          = lookup(var.tags_for_resource, "aws_nat_gateway", var.tags)
+  tags          = merge(var.tags, lookup(var.tags_for_resource, "aws_nat_gateway", {}))
 }

--- a/modules/nat-gateways/main.tf
+++ b/modules/nat-gateways/main.tf
@@ -9,5 +9,5 @@ resource "aws_nat_gateway" "natgw" {
 
   allocation_id = element(aws_eip.natgw.*.id, count.index)
   subnet_id     = element(var.subnet_ids, count.index)
-  tags          = var.tags
+  tags          = lookup(var.tags_for_resource, "aws_nat_gateway", var.tags)
 }

--- a/modules/nat-gateways/variables.tf
+++ b/modules/nat-gateways/variables.tf
@@ -13,3 +13,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}

--- a/modules/private-subnets/README.md
+++ b/modules/private-subnets/README.md
@@ -34,10 +34,11 @@ module "private_subnets" {
 | availability_zones | A list of availability zones to create the subnets in | list | - | yes |
 | cidr_block | The larger CIDR block to use for calculating individual subnet CIDR blocks | string | - | yes |
 | nat_gateway_count | The number of NAT gateways to use for routing, must match subnet_count and nat_gateway_ids | string | `0` | no |
-| nat_gateway_ids | A list of NAT Gateway IDs to use for routing | string | `<list>` | no |
-| propagating_vgws | A list of virtual gateways for route propagation | list | `<list>` | no |
+| nat_gateway_ids | A list of NAT Gateway IDs to use for routing | string | - | no |
+| propagating_vgws | A list of virtual gateways for route propagation | list | - | no |
 | subnet_count | The number of subnets to create | string | - | yes |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
 | vpc_id | The ID of the VPC to create the subnets in | string | - | yes |
 
 ## Outputs

--- a/modules/private-subnets/main.tf
+++ b/modules/private-subnets/main.tf
@@ -7,6 +7,7 @@ module "subnets" {
   availability_zones = var.availability_zones
   propagating_vgws   = var.propagating_vgws
   tags               = var.tags
+  tags_for_resource  = var.tags_for_resource
 }
 
 resource "aws_route" "nat_gateway" {

--- a/modules/private-subnets/variables.tf
+++ b/modules/private-subnets/variables.tf
@@ -32,6 +32,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}
+
 # Private subnet variables
 
 variable "nat_gateway_count" {

--- a/modules/public-subnets/README.md
+++ b/modules/public-subnets/README.md
@@ -37,9 +37,10 @@ module "public_subnets" {
 | cidr_block | The larger CIDR block to use for calculating individual subnet CIDR blocks | string | - | yes |
 | gateway_id | The ID of the Internet Gateway to use for routing | string | - | yes |
 | map_public_ip_on_launch | Assign a public IP address to instances launched into these subnets | string | `false` | no |
-| propagating_vgws | A list of virtual gateways for route propagation | list | `<list>` | no |
+| propagating_vgws | A list of virtual gateways for route propagation | list | - | no |
 | subnet_count | The number of subnets to create | string | - | yes |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
 | vpc_id | The ID of the VPC to create the subnets in | string | - | yes |
 
 ## Outputs

--- a/modules/public-subnets/main.tf
+++ b/modules/public-subnets/main.tf
@@ -7,6 +7,7 @@ module "subnets" {
   availability_zones = var.availability_zones
   propagating_vgws   = var.propagating_vgws
   tags               = var.tags
+  tags_for_resource  = var.tags_for_resource
 
   map_public_ip_on_launch = var.map_public_ip_on_launch
 }

--- a/modules/public-subnets/variables.tf
+++ b/modules/public-subnets/variables.tf
@@ -32,6 +32,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}
+
 # Public subnet variables
 
 variable "map_public_ip_on_launch" {

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -15,9 +15,10 @@ This is a lower level module. Consider using the [private-subnets](../private-su
 | availability_zones | A list of availability zones to create the subnets in | list | - | yes |
 | cidr_block | The larger CIDR block to use for calculating individual subnet CIDR blocks | string | - | yes |
 | map_public_ip_on_launch | Assign a public IP address to instances launched into these subnets | string | `false` | no |
-| propagating_vgws | A list of virtual gateways for route propagation | list | `<list>` | no |
+| propagating_vgws | A list of virtual gateways for route propagation | list | - | no |
 | subnet_count | The number of subnets to create | string | - | yes |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
 | vpc_id | The ID of the VPC to create the subnets in | string | - | yes |
 
 ## Outputs

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -7,7 +7,7 @@ resource "aws_subnet" "subnets" {
 
   map_public_ip_on_launch = var.map_public_ip_on_launch
 
-  tags = var.tags
+  tags = lookup(var.tags_for_resource, "aws_subnet", var.tags)
 }
 
 resource "aws_route_table" "default" {
@@ -16,7 +16,7 @@ resource "aws_route_table" "default" {
   vpc_id           = var.vpc_id
   propagating_vgws = var.propagating_vgws
 
-  tags = var.tags
+  tags = lookup(var.tags_for_resource, "aws_route_table", var.tags)
 }
 
 resource "aws_route_table_association" "default" {

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -7,7 +7,7 @@ resource "aws_subnet" "subnets" {
 
   map_public_ip_on_launch = var.map_public_ip_on_launch
 
-  tags = lookup(var.tags_for_resource, "aws_subnet", var.tags)
+  tags = merge(var.tags, lookup(var.tags_for_resource, "aws_subnet", {}))
 }
 
 resource "aws_route_table" "default" {
@@ -16,7 +16,7 @@ resource "aws_route_table" "default" {
   vpc_id           = var.vpc_id
   propagating_vgws = var.propagating_vgws
 
-  tags = lookup(var.tags_for_resource, "aws_route_table", var.tags)
+  tags = merge(var.tags, lookup(var.tags_for_resource, "aws_route_table", {}))
 }
 
 resource "aws_route_table_association" "default" {

--- a/modules/subnets/variables.tf
+++ b/modules/subnets/variables.tf
@@ -32,6 +32,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}
+
 # Public subnet variables
 
 variable "map_public_ip_on_launch" {

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -20,11 +20,13 @@ module "vpc" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | cidr_block | The CIDR block for the VPC | string | - | yes |
-| domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | `` | no |
-| domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `<list>` | no |
+| domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | - | no |
+| domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `AmazonProvidedDNS` | no |
 | enable_dns_hostnames | Enable DNS hostnames in the VPC | string | `false` | no |
 | enable_dns_support | Enable DNS support in the VPC | string | `true` | no |
-| tags | A map of tags to assign to resources | map | `<map>` | no |
+| tags | A map of tags to assign to resources | map | - | no |
+| tags_for_resource | A nested map of tags to assign to specific resource types | map | - | no |
+
 
 ## Outputs
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -4,12 +4,12 @@ resource "aws_vpc" "vpc" {
   cidr_block           = var.cidr_block
   enable_dns_support   = var.enable_dns_support
   enable_dns_hostnames = var.enable_dns_hostnames
-  tags                 = lookup(var.tags_for_resource, "aws_vpc", var.tags)
+  tags                 = merge(var.tags, lookup(var.tags_for_resource, "aws_vpc", {}))
 }
 
 resource "aws_default_route_table" "vpc" {
   default_route_table_id = aws_vpc.vpc.default_route_table_id
-  tags                   = lookup(var.tags_for_resource, "aws_default_route_table", var.tags)
+  tags                   = merge(var.tags, lookup(var.tags_for_resource, "aws_default_route_table", {}))
 }
 
 resource "aws_vpc_dhcp_options" "vpc" {
@@ -18,7 +18,7 @@ resource "aws_vpc_dhcp_options" "vpc" {
     "${data.aws_region.current.name}.compute.internal",
   )
   domain_name_servers = var.domain_name_servers
-  tags                = lookup(var.tags_for_resource, "aws_vpc_dhcp_options", var.tags)
+  tags                = merge(var.tags, lookup(var.tags_for_resource, "aws_vpc_dhcp_options", {}))
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp" {
@@ -28,5 +28,5 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp" {
 
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.vpc.id
-  tags   = lookup(var.tags_for_resource, "aws_internet_gateway", var.tags)
+  tags   = merge(var.tags, lookup(var.tags_for_resource, "aws_internet_gateway", {}))
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,16 +1,15 @@
-data "aws_region" "current" {
-}
+data "aws_region" "current" {}
 
 resource "aws_vpc" "vpc" {
   cidr_block           = var.cidr_block
   enable_dns_support   = var.enable_dns_support
   enable_dns_hostnames = var.enable_dns_hostnames
-  tags                 = var.tags
+  tags                 = lookup(var.tags_for_resource, "aws_vpc", var.tags)
 }
 
 resource "aws_default_route_table" "vpc" {
   default_route_table_id = aws_vpc.vpc.default_route_table_id
-  tags                   = var.tags
+  tags                   = lookup(var.tags_for_resource, "aws_default_route_table", var.tags)
 }
 
 resource "aws_vpc_dhcp_options" "vpc" {
@@ -19,7 +18,7 @@ resource "aws_vpc_dhcp_options" "vpc" {
     "${data.aws_region.current.name}.compute.internal",
   )
   domain_name_servers = var.domain_name_servers
-  tags                = var.tags
+  tags                = lookup(var.tags_for_resource, "aws_vpc_dhcp_options", var.tags)
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp" {
@@ -29,5 +28,5 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp" {
 
 resource "aws_internet_gateway" "igw" {
   vpc_id = aws_vpc.vpc.id
-  tags   = var.tags
+  tags   = lookup(var.tags_for_resource, "aws_internet_gateway", var.tags)
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -35,3 +35,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_for_resource" {
+  description = "A nested map of tags to assign to specific resource types"
+  type        = map(map(string))
+  default     = {}
+}
+
 # VPC variables
 
 variable "vpc_cidr_block" {


### PR DESCRIPTION
EKS requires specific tags on the VPC and subnet resources, but it doesn't make sense to add them to the route tables, for example. This lets me set tags for specific resources.