### PR TITLE
Make DHCP Options optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module "vpc" {
 | availability_zones | A list of availability zones to create subnets in | list | - | yes |
 | domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | - | no |
 | domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `AmazonProvidedDNS` | no |
+| enable_dhcp_options | Enable creation of DHCP Options | string | `true` | no |
 | enable_dns_hostnames | Enable DNS hostnames in the VPC | string | `false` | no |
 | enable_dns_support | Enable DNS support in the VPC | string | `true` | no |
 | map_public_ip_on_launch | Assign a public IP address to instances launched into the public subnets | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ module "vpc" {
   source = "./modules/vpc"
 
   cidr_block           = var.vpc_cidr_block
+  enable_dhcp_options  = var.enable_dhcp_options
   enable_dns_support   = var.enable_dns_support
   enable_dns_hostnames = var.enable_dns_hostnames
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -22,6 +22,7 @@ module "vpc" {
 | cidr_block | The CIDR block for the VPC | string | - | yes |
 | domain_name | The suffix domain to use by default when resolving non Full Qualified Domain Names, if left blank then <region>.compute.internal will be used | string | - | no |
 | domain_name_servers | List of name servers to configure in /etc/resolve.conf, defaults to the default AWS nameservers | list | `AmazonProvidedDNS` | no |
+| enable_dhcp_options | Enable creation of DHCP Options | string | `true` | no |
 | enable_dns_hostnames | Enable DNS hostnames in the VPC | string | `false` | no |
 | enable_dns_support | Enable DNS support in the VPC | string | `true` | no |
 | tags | A map of tags to assign to resources | map | - | no |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -13,6 +13,8 @@ resource "aws_default_route_table" "vpc" {
 }
 
 resource "aws_vpc_dhcp_options" "vpc" {
+  count = var.enable_dhcp_options == true ? 1 : 0
+
   domain_name = coalesce(
     var.domain_name,
     "${data.aws_region.current.name}.compute.internal",
@@ -22,8 +24,9 @@ resource "aws_vpc_dhcp_options" "vpc" {
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp" {
+  count           = var.enable_dhcp_options == true ? 1 : 0
   vpc_id          = aws_vpc.vpc.id
-  dhcp_options_id = aws_vpc_dhcp_options.vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.vpc[0].id
 }
 
 resource "aws_internet_gateway" "igw" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -3,6 +3,12 @@ variable "cidr_block" {
   type        = string
 }
 
+variable "enable_dhcp_options" {
+  description = "Enable creation of DHCP Options"
+  type        = bool
+  default     = true
+}
+
 variable "enable_dns_support" {
   description = "Enable DNS support in the VPC"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "vpc_cidr_block" {
   type        = string
 }
 
+variable "enable_dhcp_options" {
+  description = "Enable creation of DHCP Options"
+  type        = bool
+  default     = true
+}
+
 variable "enable_dns_support" {
   description = "Enable DNS support in the VPC"
   type        = string


### PR DESCRIPTION
We have a use-case where we need to provide custom DHCP Options and thus don't need the one that this module provides.  By default, if we attach our own, it will flap between that and the one in the module.

This is a non-breaking change and defaults to the existing behaviour.