### PR TITLE
Allow for separate tagging between public and private subnets.

### DIFF
--- a/modules/private-subnets/main.tf
+++ b/modules/private-subnets/main.tf
@@ -7,7 +7,10 @@ module "subnets" {
   availability_zones = var.availability_zones
   propagating_vgws   = var.propagating_vgws
   tags               = var.tags
-  tags_for_resource  = var.tags_for_resource
+  tags_for_resource  = merge(
+    var.tags_for_resource,
+    { "aws_subnet" = lookup(var.tags_for_resource, "private_subnet", {}) }
+  )
 }
 
 resource "aws_route" "nat_gateway" {

--- a/modules/public-subnets/main.tf
+++ b/modules/public-subnets/main.tf
@@ -7,7 +7,10 @@ module "subnets" {
   availability_zones = var.availability_zones
   propagating_vgws   = var.propagating_vgws
   tags               = var.tags
-  tags_for_resource  = var.tags_for_resource
+  tags_for_resource  = merge(
+    var.tags_for_resource,
+    { "aws_subnet" = lookup(var.tags_for_resource, "public_subnet", {}) }
+  )
 
   map_public_ip_on_launch = var.map_public_ip_on_launch
 }


### PR DESCRIPTION
[AWS Loadbalancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/) requires tagging on type of subnet for internal or public-facing loadbalancers.